### PR TITLE
Update CORD.JS version to 0.9.3-1rc20 & Use upstream for createdDid

### DIFF
--- a/demo/src/test-vc.ts
+++ b/demo/src/test-vc.ts
@@ -1,6 +1,4 @@
 import * as Cord from '@cord.network/sdk';
-import { createDid } from './generateDid';
-import { randomUUID } from 'crypto';
 import 'dotenv/config';
 
 import fs from 'fs';
@@ -43,11 +41,11 @@ async function main() {
 
     // Create Holder DID
     const { mnemonic: holderMnemonic, document: holderDid } =
-        await createDid(authorIdentity);
+        await Cord.Did.createDid(authorIdentity);
 
     // Create issuer DID
     const { mnemonic: issuerMnemonic, document: issuerDid } =
-        await createDid(authorIdentity);
+        await Cord.Did.createDid(authorIdentity);
     const issuerKeys = Cord.Utils.Keys.generateKeypairs(
         issuerMnemonic,
         'sr25519',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@cord.network/vc-export",
-    "version": "0.9.3-1rc2",
+    "version": "0.9.3-1rc20",
     "description": "Provides the option to build and verify VCs and VPs",
     "main": "./lib/cjs/index.js",
     "module": "./lib/esm/index.js",
@@ -39,7 +39,7 @@
         "typescript": "^4.8.3"
     },
     "dependencies": {
-        "@cord.network/sdk": "0.9.1-1rc18",
+        "@cord.network/sdk": "0.9.3-1rc20",
         "moment": "^2.29.4"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -32,59 +32,59 @@
   resolved "https://registry.yarnpkg.com/@cbor-extract/cbor-extract-win32-x64/-/cbor-extract-win32-x64-2.2.0.tgz#4b3f07af047f984c082de34b116e765cb9af975f"
   integrity sha512-l2M+Z8DO2vbvADOBNLbbh9y5ST1RY5sqkWOg/58GkUPBYou/cuNZ68SGQ644f1CvZ8kcOxyZtw06+dxWHIoN/w==
 
-"@cord.network/asset@0.9.1-1rc18":
-  version "0.9.1-1rc18"
-  resolved "https://registry.yarnpkg.com/@cord.network/asset/-/asset-0.9.1-1rc18.tgz#ffebee04ef7605614fc02e673a83bb52a67ac4b3"
-  integrity sha512-7cJeimTodjO4WLcQXDW6CmMrIKc56nRhE6ZLg/fNeeo1qZccH4OhE1tmNyfbRqp6L5DjDv8dqQYmAkL/Zq539Q==
+"@cord.network/asset@0.9.3-1rc20":
+  version "0.9.3-1rc20"
+  resolved "https://registry.yarnpkg.com/@cord.network/asset/-/asset-0.9.3-1rc20.tgz#53389e287666629e8ef5b9f228c94e6c46a40e27"
+  integrity sha512-3KSnjcwH7rLpN1MCdEl03S0WVe2a5YVOpyCjs65JFyylTsvKqO4aXXcRuiSZJA60Alxi8ZwS6EilRUpluQHrRA==
   dependencies:
-    "@cord.network/config" "0.9.1-1rc18"
-    "@cord.network/did" "0.9.1-1rc18"
-    "@cord.network/identifier" "0.9.1-1rc18"
-    "@cord.network/network" "0.9.1-1rc18"
-    "@cord.network/types" "0.9.1-1rc18"
-    "@cord.network/utils" "0.9.1-1rc18"
+    "@cord.network/config" "0.9.3-1rc20"
+    "@cord.network/did" "0.9.3-1rc20"
+    "@cord.network/identifier" "0.9.3-1rc20"
+    "@cord.network/network" "0.9.3-1rc20"
+    "@cord.network/types" "0.9.3-1rc20"
+    "@cord.network/utils" "0.9.3-1rc20"
 
-"@cord.network/augment-api@0.9.1-1rc18":
-  version "0.9.1-1rc18"
-  resolved "https://registry.yarnpkg.com/@cord.network/augment-api/-/augment-api-0.9.1-1rc18.tgz#9e62841046fd58bee7f26490efa4d3ab07ae81c4"
-  integrity sha512-H22wRisIMqkbJvmQUEw9wr6y7nFAGKb5IMp/Fl779uNKmr6Np0flxzQNdmnVgEV564CkUAQizgu4k0I99upRWQ==
+"@cord.network/augment-api@0.9.3-1rc20":
+  version "0.9.3-1rc20"
+  resolved "https://registry.yarnpkg.com/@cord.network/augment-api/-/augment-api-0.9.3-1rc20.tgz#e3a826a6a5ccc93d6e4e1e8a6e4368b1b4b431be"
+  integrity sha512-xuYcgveqL/JwamiWnnOL74i14TjkkS++ijs67hjfsy+hncTSqX3xGFdkpSLcfN6f6FxavVDoi7GfuNT4m4S/wQ==
   dependencies:
-    "@cord.network/type-definitions" "0.9.1-1rc18"
+    "@cord.network/type-definitions" "0.9.3-1rc20"
     "@polkadot/rpc-augment" "^10.12.2"
     "@polkadot/rpc-core" "^10.12.2"
     "@polkadot/rpc-provider" "^10.12.2"
 
-"@cord.network/chain-space@0.9.1-1rc18":
-  version "0.9.1-1rc18"
-  resolved "https://registry.yarnpkg.com/@cord.network/chain-space/-/chain-space-0.9.1-1rc18.tgz#e80f4c6e91a5792efd8ef750aa30bfa38f9b4e85"
-  integrity sha512-zgMcXm3+53vjixS9UyRDXk/zig3nFfWJHstb9YzMAiq36Fk/tuPLX9w39X78RpPNboMsEChVH++SHAFl/FQwAg==
+"@cord.network/chain-space@0.9.3-1rc20":
+  version "0.9.3-1rc20"
+  resolved "https://registry.yarnpkg.com/@cord.network/chain-space/-/chain-space-0.9.3-1rc20.tgz#108fd9b55625f827294a853260c57cb92a42249a"
+  integrity sha512-h52UPAABssAE1CzNtVUmugq7A36qRwN/GIm0UgcD8CBZSg4fj3gZwgE151H03Hk3DXgRpwiWpT/wQBLII78CCw==
   dependencies:
-    "@cord.network/config" "0.9.1-1rc18"
-    "@cord.network/did" "0.9.1-1rc18"
-    "@cord.network/identifier" "0.9.1-1rc18"
-    "@cord.network/network" "0.9.1-1rc18"
-    "@cord.network/types" "0.9.1-1rc18"
-    "@cord.network/utils" "0.9.1-1rc18"
+    "@cord.network/config" "0.9.3-1rc20"
+    "@cord.network/did" "0.9.3-1rc20"
+    "@cord.network/identifier" "0.9.3-1rc20"
+    "@cord.network/network" "0.9.3-1rc20"
+    "@cord.network/types" "0.9.3-1rc20"
+    "@cord.network/utils" "0.9.3-1rc20"
 
-"@cord.network/config@0.9.1-1rc18":
-  version "0.9.1-1rc18"
-  resolved "https://registry.yarnpkg.com/@cord.network/config/-/config-0.9.1-1rc18.tgz#345e16e26599e0f92cc8cfb9c270822e7b6cfe80"
-  integrity sha512-eW/q/47k/hP+qUVzA+qlr6mqjLIAcNMiOV8HyW+u9ZILoImFJqqGthbbCRILvSmH3QeR4l+Rzkznq0vj+1sfeg==
+"@cord.network/config@0.9.3-1rc20":
+  version "0.9.3-1rc20"
+  resolved "https://registry.yarnpkg.com/@cord.network/config/-/config-0.9.3-1rc20.tgz#2e21eda4a1248d07d4b403041b6b88153d9fc42e"
+  integrity sha512-6GwOhBC36BQRsyA1mvUTNVSuxFDn6p19QRmA1A+6TMrOQDvNdXByk7F7yXqwGMB/u2BIvxYjwjbRXb/RKctC9Q==
   dependencies:
-    "@cord.network/type-definitions" "0.9.1-1rc18"
-    "@cord.network/types" "0.9.1-1rc18"
-    "@cord.network/utils" "0.9.1-1rc18"
+    "@cord.network/type-definitions" "0.9.3-1rc20"
+    "@cord.network/types" "0.9.3-1rc20"
+    "@cord.network/utils" "0.9.3-1rc20"
 
-"@cord.network/did@0.9.1-1rc18":
-  version "0.9.1-1rc18"
-  resolved "https://registry.yarnpkg.com/@cord.network/did/-/did-0.9.1-1rc18.tgz#597ae12dd19d41be255f21bfce87ef571874f0e2"
-  integrity sha512-KcWCAmAEOlp4oFBVSy7Y+8BPkLxuBdAmDCEQhdhQ773G1X1ONvGqH/h5542pi4s3t1BTpWYeGi1+wpHQJs5gJg==
+"@cord.network/did@0.9.3-1rc20":
+  version "0.9.3-1rc20"
+  resolved "https://registry.yarnpkg.com/@cord.network/did/-/did-0.9.3-1rc20.tgz#4542d45148a49c217841a9241d3975dfd0fee307"
+  integrity sha512-QpdtbFur88nCSGbsim7t50JpcMyGdhj91xm1fV+KHRs9UQo2NxAC+fcdAf/BM34GM299RwU1VZDteVe4xaomrQ==
   dependencies:
-    "@cord.network/augment-api" "0.9.1-1rc18"
-    "@cord.network/config" "0.9.1-1rc18"
-    "@cord.network/network" "0.9.1-1rc18"
-    "@cord.network/types" "0.9.1-1rc18"
-    "@cord.network/utils" "0.9.1-1rc18"
+    "@cord.network/augment-api" "0.9.3-1rc20"
+    "@cord.network/config" "0.9.3-1rc20"
+    "@cord.network/network" "0.9.3-1rc20"
+    "@cord.network/types" "0.9.3-1rc20"
+    "@cord.network/utils" "0.9.3-1rc20"
     "@digitalbazaar/security-context" "^1.0.1"
     "@polkadot/api" "^10.12.2"
     "@polkadot/keyring" "^12.6.2"
@@ -93,91 +93,103 @@
     "@polkadot/util" "^12.6.2"
     "@polkadot/util-crypto" "^12.6.2"
 
-"@cord.network/identifier@0.9.1-1rc18":
-  version "0.9.1-1rc18"
-  resolved "https://registry.yarnpkg.com/@cord.network/identifier/-/identifier-0.9.1-1rc18.tgz#e86dd8edd461c21fe99e497ca8ea48eb9cbe4e15"
-  integrity sha512-RyuAejuu8dEilvOAXdpo0w97S0VV2mMwTPHEx87s7CtYw0BlZ9iwQxQMrrQjIE8RwxhPoZLzODzYauQDCPtOQw==
+"@cord.network/identifier@0.9.3-1rc20":
+  version "0.9.3-1rc20"
+  resolved "https://registry.yarnpkg.com/@cord.network/identifier/-/identifier-0.9.3-1rc20.tgz#8bcbf0d0df50c79a9df28ac7d6f2886729d56405"
+  integrity sha512-0unZ2viBaPGSapeYngRkwX0hl7Vq/rP4qb7z34ITeaSM/GkAL1fkIc3WBPqTDtCyJ1JOhOycskmT/4QBM+sFHQ==
   dependencies:
-    "@cord.network/types" "0.9.1-1rc18"
-    "@cord.network/utils" "0.9.1-1rc18"
+    "@cord.network/types" "0.9.3-1rc20"
+    "@cord.network/utils" "0.9.3-1rc20"
 
-"@cord.network/network-score@0.9.1-1rc18":
-  version "0.9.1-1rc18"
-  resolved "https://registry.yarnpkg.com/@cord.network/network-score/-/network-score-0.9.1-1rc18.tgz#2f287d6e494944160167599839d938caf2fe4908"
-  integrity sha512-YYf3EDwVViP/74yI7WBv8mQN+bo57KB2m4tmJoajHbTvc7hiwAtpFYi8zhprnQCAzGKp16ZlkCjCRr66PPfZvg==
+"@cord.network/network-score@0.9.3-1rc20":
+  version "0.9.3-1rc20"
+  resolved "https://registry.yarnpkg.com/@cord.network/network-score/-/network-score-0.9.3-1rc20.tgz#6e8e652e95f9c23d01976714bd4211b96ff0fc3c"
+  integrity sha512-VTvhdeSelija/XCd4QfIRfab6VJGa1V9uve7Nq9ZqZ+qRqpuvdSEP//JrQ1yKEurvF0t23+wPKrby5UPQdC+/Q==
   dependencies:
-    "@cord.network/config" "0.9.1-1rc18"
-    "@cord.network/did" "0.9.1-1rc18"
-    "@cord.network/identifier" "0.9.1-1rc18"
-    "@cord.network/network" "0.9.1-1rc18"
-    "@cord.network/types" "0.9.1-1rc18"
-    "@cord.network/utils" "0.9.1-1rc18"
+    "@cord.network/config" "0.9.3-1rc20"
+    "@cord.network/did" "0.9.3-1rc20"
+    "@cord.network/identifier" "0.9.3-1rc20"
+    "@cord.network/network" "0.9.3-1rc20"
+    "@cord.network/types" "0.9.3-1rc20"
+    "@cord.network/utils" "0.9.3-1rc20"
 
-"@cord.network/network@0.9.1-1rc18":
-  version "0.9.1-1rc18"
-  resolved "https://registry.yarnpkg.com/@cord.network/network/-/network-0.9.1-1rc18.tgz#48f128a0139be1c8ced2612c83fc64a8edaeedb3"
-  integrity sha512-V8lWVWsWoS5eztuHMeoXxoluR+9ryDZk2nBFUf/A2GxHb9EhjdLx/20xkjLorG0TZZ/Pac6gL7IgGTZ9NCFltQ==
+"@cord.network/network@0.9.3-1rc20":
+  version "0.9.3-1rc20"
+  resolved "https://registry.yarnpkg.com/@cord.network/network/-/network-0.9.3-1rc20.tgz#206328144236b4cdd9042d08d9d44277d22077f7"
+  integrity sha512-2Pw3D0Xwu8kG3NhezjS6n2ncmoDeTnxre83u519m79+trecb2UanIHis7c0PbnyEXwGnZ9DHJagHTzWnaILsFQ==
   dependencies:
-    "@cord.network/config" "0.9.1-1rc18"
-    "@cord.network/types" "0.9.1-1rc18"
-    "@cord.network/utils" "0.9.1-1rc18"
+    "@cord.network/config" "0.9.3-1rc20"
+    "@cord.network/types" "0.9.3-1rc20"
+    "@cord.network/utils" "0.9.3-1rc20"
     "@polkadot/api" "^10.12.2"
     "@polkadot/types" "^10.12.2"
 
-"@cord.network/schema@0.9.1-1rc18":
-  version "0.9.1-1rc18"
-  resolved "https://registry.yarnpkg.com/@cord.network/schema/-/schema-0.9.1-1rc18.tgz#2c1358e2cdad20c61918310d673796e682e03e80"
-  integrity sha512-KDKwD3oU3SD/fYBfpQcsKsy1/K2EcEd8zVOl1gbs3VRxHaLHP+GwomXGHprMCZq7ft0bNGhjjTUg9Gd9xtyUfg==
+"@cord.network/registries@0.9.3-1rc20":
+  version "0.9.3-1rc20"
+  resolved "https://registry.yarnpkg.com/@cord.network/registries/-/registries-0.9.3-1rc20.tgz#0c6a9e0a0017e211c0e424ae8e74c7ae6dbd601f"
+  integrity sha512-3vufoqoZJLyQP5Uq/yow1n6ljskM4NgLypCFlWk/o13CLl1duJ5QO2+8E77xbbZOPSurGnZf6ZVruLZIQe5/nA==
   dependencies:
-    "@cord.network/augment-api" "0.9.1-1rc18"
-    "@cord.network/chain-space" "0.9.1-1rc18"
-    "@cord.network/config" "0.9.1-1rc18"
-    "@cord.network/did" "0.9.1-1rc18"
-    "@cord.network/identifier" "0.9.1-1rc18"
-    "@cord.network/network" "0.9.1-1rc18"
-    "@cord.network/types" "0.9.1-1rc18"
-    "@cord.network/utils" "0.9.1-1rc18"
+    "@cord.network/config" "0.9.3-1rc20"
+    "@cord.network/identifier" "0.9.3-1rc20"
+    "@cord.network/network" "0.9.3-1rc20"
+    "@cord.network/types" "0.9.3-1rc20"
+    "@cord.network/utils" "0.9.3-1rc20"
 
-"@cord.network/sdk@0.9.1-1rc18":
-  version "0.9.1-1rc18"
-  resolved "https://registry.yarnpkg.com/@cord.network/sdk/-/sdk-0.9.1-1rc18.tgz#9344d676c3c6991ee9331ae8bea4cffe490363b5"
-  integrity sha512-bhP/LdIT5VRJWEVRJX7/EIk4vjPAO7rski36PC7LZymoTytjhkTlqM7wxPvW7etkPgBpVoMF+Z7WZEur3/7/tA==
+"@cord.network/schema@0.9.3-1rc20":
+  version "0.9.3-1rc20"
+  resolved "https://registry.yarnpkg.com/@cord.network/schema/-/schema-0.9.3-1rc20.tgz#2003ccd49eae25706e1c41fe64600707dc1be90c"
+  integrity sha512-PV3KmSyrfdthvol26Qow4ZNGUic3nbantjocjoj6hZBG6r7PAZl7WTjEf64cV2cRTiuCJhnt/eMuLJy++/3Yvg==
   dependencies:
-    "@cord.network/asset" "0.9.1-1rc18"
-    "@cord.network/chain-space" "0.9.1-1rc18"
-    "@cord.network/config" "0.9.1-1rc18"
-    "@cord.network/did" "0.9.1-1rc18"
-    "@cord.network/identifier" "0.9.1-1rc18"
-    "@cord.network/network" "0.9.1-1rc18"
-    "@cord.network/network-score" "0.9.1-1rc18"
-    "@cord.network/schema" "0.9.1-1rc18"
-    "@cord.network/statement" "0.9.1-1rc18"
-    "@cord.network/types" "0.9.1-1rc18"
-    "@cord.network/utils" "0.9.1-1rc18"
+    "@cord.network/augment-api" "0.9.3-1rc20"
+    "@cord.network/chain-space" "0.9.3-1rc20"
+    "@cord.network/config" "0.9.3-1rc20"
+    "@cord.network/did" "0.9.3-1rc20"
+    "@cord.network/identifier" "0.9.3-1rc20"
+    "@cord.network/network" "0.9.3-1rc20"
+    "@cord.network/types" "0.9.3-1rc20"
+    "@cord.network/utils" "0.9.3-1rc20"
 
-"@cord.network/statement@0.9.1-1rc18":
-  version "0.9.1-1rc18"
-  resolved "https://registry.yarnpkg.com/@cord.network/statement/-/statement-0.9.1-1rc18.tgz#9e4f0d2e2b20ba9b7f01303ac8efa852fe78a713"
-  integrity sha512-K1fW61j3YH00EjpKqdgTmfdtUeaTx99cUJSMMDZa4f+dNKoXAH9caDDUp04+PuIJcdNZVlB35ZzKxDNGkPE75A==
+"@cord.network/sdk@0.9.3-1rc20":
+  version "0.9.3-1rc20"
+  resolved "https://registry.yarnpkg.com/@cord.network/sdk/-/sdk-0.9.3-1rc20.tgz#f40cb91743c56b14dc6cb49a76fe08243e73a572"
+  integrity sha512-W8/l6gV7h/QM/xK2sGbd0PY61v2JdUEFN0nKjW+YjruMARiq/PYn+G5iKFj57G7N9xosqBGJtCYzG0Xyqf192w==
   dependencies:
-    "@cord.network/config" "0.9.1-1rc18"
-    "@cord.network/did" "0.9.1-1rc18"
-    "@cord.network/identifier" "0.9.1-1rc18"
-    "@cord.network/network" "0.9.1-1rc18"
-    "@cord.network/types" "0.9.1-1rc18"
-    "@cord.network/utils" "0.9.1-1rc18"
+    "@cord.network/asset" "0.9.3-1rc20"
+    "@cord.network/chain-space" "0.9.3-1rc20"
+    "@cord.network/config" "0.9.3-1rc20"
+    "@cord.network/did" "0.9.3-1rc20"
+    "@cord.network/identifier" "0.9.3-1rc20"
+    "@cord.network/network" "0.9.3-1rc20"
+    "@cord.network/network-score" "0.9.3-1rc20"
+    "@cord.network/registries" "0.9.3-1rc20"
+    "@cord.network/schema" "0.9.3-1rc20"
+    "@cord.network/statement" "0.9.3-1rc20"
+    "@cord.network/types" "0.9.3-1rc20"
+    "@cord.network/utils" "0.9.3-1rc20"
 
-"@cord.network/type-definitions@0.9.1-1rc18":
-  version "0.9.1-1rc18"
-  resolved "https://registry.yarnpkg.com/@cord.network/type-definitions/-/type-definitions-0.9.1-1rc18.tgz#dd6866ccb1f64cc43a61979b29c15226b8f5d34f"
-  integrity sha512-1MJIARoDt5ChqBF5u5Xb7lARRDbmcc9i+Ztbfl7P2utnJyiqqIp4sWbfO2ZDpSpQk3AzQ1rQGn+bbbQ8lWqF0g==
+"@cord.network/statement@0.9.3-1rc20":
+  version "0.9.3-1rc20"
+  resolved "https://registry.yarnpkg.com/@cord.network/statement/-/statement-0.9.3-1rc20.tgz#0d042c056520dd3b31e53af3a78209f17ecbf196"
+  integrity sha512-KmsWJAacEwkuQdHPRYTlr9ZlRlGWfvZF5Tvf2eGXX0OrlXEkWkMzFI2xe4DMyTUTpB8L2HI3mMrw0F0WKXJbDg==
+  dependencies:
+    "@cord.network/config" "0.9.3-1rc20"
+    "@cord.network/did" "0.9.3-1rc20"
+    "@cord.network/identifier" "0.9.3-1rc20"
+    "@cord.network/network" "0.9.3-1rc20"
+    "@cord.network/types" "0.9.3-1rc20"
+    "@cord.network/utils" "0.9.3-1rc20"
+
+"@cord.network/type-definitions@0.9.3-1rc20":
+  version "0.9.3-1rc20"
+  resolved "https://registry.yarnpkg.com/@cord.network/type-definitions/-/type-definitions-0.9.3-1rc20.tgz#b2a7311f671839347700ac88d655187c31f01bee"
+  integrity sha512-02ZCd7AEslITgCBBlBggattPmbHrvyF2Tk6Df/Us3RN9XQRn0EGirik/a7nvbggP6uHUucPxSj4w4MYLSYdkPw==
   dependencies:
     "@polkadot/types" "^10.12.2"
 
-"@cord.network/types@0.9.1-1rc18":
-  version "0.9.1-1rc18"
-  resolved "https://registry.yarnpkg.com/@cord.network/types/-/types-0.9.1-1rc18.tgz#0dc994da6287d1571835cc572a9569d50c34279a"
-  integrity sha512-QZAQc0/sucrzGo/SoAqwojXk6dRr37cqg2T5T2Bt+/VzzHGtpdy7zOAqsmtY+kLPTfFJrF/OykDjneo8dimifQ==
+"@cord.network/types@0.9.3-1rc20":
+  version "0.9.3-1rc20"
+  resolved "https://registry.yarnpkg.com/@cord.network/types/-/types-0.9.3-1rc20.tgz#9ec7479906998158b11d5fa8ba0b25613c11131d"
+  integrity sha512-a02nCWQek/2oyQeO5GSH3hPgs+q4efEgrr7FdHMJBH/136hYBNU8zXPwA37k2zSO2cAzzshhJaUTykwrWbgVYQ==
   dependencies:
     "@polkadot/api" "^10.12.2"
     "@polkadot/keyring" "^12.6.2"
@@ -185,12 +197,12 @@
     "@polkadot/util" "^12.6.2"
     "@polkadot/util-crypto" "^12.6.2"
 
-"@cord.network/utils@0.9.1-1rc18":
-  version "0.9.1-1rc18"
-  resolved "https://registry.yarnpkg.com/@cord.network/utils/-/utils-0.9.1-1rc18.tgz#5363d07927e7b0be5ecdb0d5e3756a68b7322682"
-  integrity sha512-b6q03YcIwi6NZjNd9+2s3MfsMZLtbMENNs7gNhTUMQ74dueYWJtxYX3XzTCmUj/Hz4GuppmitCH9wop2Eww3jg==
+"@cord.network/utils@0.9.3-1rc20":
+  version "0.9.3-1rc20"
+  resolved "https://registry.yarnpkg.com/@cord.network/utils/-/utils-0.9.3-1rc20.tgz#5aa2f8b63d35a31b12cae2b51be400f4ef83a595"
+  integrity sha512-pLH+2JnwlQOSLz7Bnt4JxJl6yx8jYt4YRgeqtK1Uk5JIlT1hLyvhPSTBzjTfmhminqBoaN9uvJddW2HkN0e5ww==
   dependencies:
-    "@cord.network/types" "0.9.1-1rc18"
+    "@cord.network/types" "0.9.3-1rc20"
     "@polkadot/api" "^10.12.2"
     "@polkadot/keyring" "^12.6.2"
     "@polkadot/util" "^12.6.2"


### PR DESCRIPTION
This version bump is required for fixing following error:

```
cord.js/packages/did/src/Did.chain.ts:562
  const encodedDid: Option<RawDidLinkedInfo> = await api.call.didApi.query(
                                                                     ^


TypeError: Cannot read properties of undefined (reading 'query')
    at Object.createDid (cord.js/packages/did/src/Did.chain.ts:562:70)
    at main (cord.js/demo/src/func-test.ts:56:5)

Node.js v20.11.1
```

Update the `CORD.js` version to newly released version `0.9.3-1rc20`. Also update package-version of `vc-export` to be `0.9.3-1rc20`.