### PR TITLE
VerifyUtils: Make Verify VP work

### DIFF
--- a/demo/src/test-vc.ts
+++ b/demo/src/test-vc.ts
@@ -265,8 +265,12 @@ async function main() {
     );
     console.dir(vp, { colors: true, depth: null });
 
-    /* VP verification would 'throw' an error in case of error */
-    //await verifyVP(vp);
+    console.log("Verifing VP...")
+    // NOTE: New step of sending a record map with respective VC:EntryId's,
+    // Required since we do not have Entry Id in the VC itself.
+    // Which can be potentially solved with doken-precomputer.
+    await verifyVP(vp, api, { [vc.id]: entryIdentifier });
+    console.log("VP Verified Succesfully!")
 
     /* sample for document hash anchor on CORD */
     /* Can be moved at last of the demo-script, so the flow is not broken */

--- a/src/verifyUtils.ts
+++ b/src/verifyUtils.ts
@@ -482,13 +482,25 @@ export async function verifyVC(
     return;
 }
 
-export async function verifyVP(vp: VerifiablePresentation, api: Cord.ApiPromise) {
-    /* proof check */
-    await verifyProofElement(vp.proof as VCProof, undefined, undefined, api);
-
-    let vcs = vp.VerifiableCredential;
-    for (let i = 0; i < vcs.length; i++) {
-        let vc = vcs[i];
-        await verifyVC(vc, api);
-    }
-}
+export async function verifyVP(
+     vp: VerifiablePresentation, 
+     api: Cord.ApiPromise,
+     vcEntryIdMap: Record<string, string>
+ ) {
+     /* proof check */
+     await verifyProofElement(vp.proof as VCProof, undefined, undefined, api);
+     
+     let vcs = vp.VerifiableCredential;
+     for (let i = 0; i < vcs.length; i++) {
+         let vc = vcs[i];
+          const entryId = vcEntryIdMap[vc.id];
+         // TODO: Handling here will not be optimal, because
+         // the CORD-PROOF-2025 is optional, not every VC will have it.
+         // Instead handle while calling VerifyVP, if the VC's Proof object type has
+         // CordProof2025 embedded.
+         // if (!entryId || !vc.id) {
+         //     throw new Error(`Missing entry identifier for VC with ID: ${vc.id}`);
+         // }
+         await verifyVC(vc, api, entryId);
+         }
+ }


### PR DESCRIPTION
Extra requirement is passing a map of vc's to its respective entryIds.

TODO:
For future we can use `doken-precomputer` and include URIs onto VCs itself.